### PR TITLE
small fixes, hide deprecation message in php 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ use App\Models\User;
 
 abstract class TestCase extends RestTestCase
 {
-    protected function createApplication() : Application{
+    protected function createApplication(): Application
+    {
         $container = new Container();
         // register service providers here
         return new Application($container);
@@ -68,7 +69,7 @@ class UsersTest extends TestCase
             ->assertResponseIsSuccessful()
             ->assertResponseCodeIsOk()
             ->assertHeader('Content-Type', 'application/json')
-            ->assertResponseContainsJsonFragment(['id' => 1])
+            ->assertResponseContainsJsonFragment(['id' => 1]);
     }
 }
 ```
@@ -161,7 +162,7 @@ class UserFixture extends EntityFixture
     
     public function __construct(UserHydrator $hydrator, UserTableGateway $tableGateway) 
     {
-        parent::__construct($hydrator,$tableGateway);
+        parent::__construct($hydrator, $tableGateway);
     }   
 }
 ```
@@ -208,7 +209,7 @@ class UserProfileFixture extends EntityFixture
     
     public function __construct(UserProfileHydrator $hydrator, UserProfileTableGateway $tableGateway) 
     {
-        parent::__construct($hydrator,$tableGateway);
+        parent::__construct($hydrator, $tableGateway);
     }   
 }
 ```
@@ -224,9 +225,9 @@ trait and implement `fixtures()` method
 
 namespace Test;
 
-use Domain/Profile/Profile;
-use Test/Fixture/UserFixture;
-use Test/Fixture/UserProfileFixture;
+use Domain\Profile\Profile;
+use Test\Fixture\UserFixture;
+use Test\Fixture\UserProfileFixture;
 use WhirlwindApplicationTesting\Traits\InteractWithFixtures;
 
 class UsersTest extends TestCase
@@ -240,10 +241,10 @@ class UsersTest extends TestCase
             ->assertResponseIsSuccessful()
             ->assertResponseCodeIsOk()
             ->assertHeader('Content-Type', 'application/json')
-            ->assertResponseContainsJsonFragment(['id' => 1])
+            ->assertResponseContainsJsonFragment(['id' => 1]);
     }
     
-    public function fixtures() : array
+    public function fixtures(): array
     {
          return [
             'users' => UserFixtureClass::class,

--- a/src/Fixture/EntityFixture.php
+++ b/src/Fixture/EntityFixture.php
@@ -10,32 +10,18 @@ use WhirlwindApplicationTesting\Fixture\Exception\InvalidConfigException;
 
 class EntityFixture extends Fixture
 {
-    /**
-     * @var Hydrator
-     */
-    protected $hydrator;
-    /**
-     * @var TableGatewayInterface
-     */
-    protected $tableGateway;
-    /**
-     * @var string
-     */
-    protected $entityClass;
+    protected Hydrator $hydrator;
 
-    /**
-     * @param Hydrator $hydrator
-     * @param TableGatewayInterface $tableGateway
-     */
+    protected TableGatewayInterface $tableGateway;
+
+    protected string $entityClass;
+
     public function __construct(Hydrator $hydrator, TableGatewayInterface $tableGateway)
     {
         $this->hydrator = $hydrator;
         $this->tableGateway = $tableGateway;
     }
 
-    /**
-     * @param string $entityClass
-     */
     public function setEntityClass(string $entityClass): void
     {
         $this->entityClass = $entityClass;

--- a/src/Fixture/Fixture.php
+++ b/src/Fixture/Fixture.php
@@ -8,18 +8,11 @@ use WhirlwindApplicationTesting\Fixture\Exception\InvalidConfigException;
 
 abstract class Fixture implements FixtureInterface, \IteratorAggregate, \ArrayAccess, \Countable
 {
-    /**
-     * @var array
-     */
-    protected $data = [];
-    /**
-     * @var array
-     */
-    protected $depends = [];
-    /**
-     * @var string
-     */
-    protected $dataFile;
+    protected array $data = [];
+
+    protected array $depends = [];
+
+    protected string $dataFile;
 
     /**
      * @param FixtureInterface[] $depends
@@ -74,6 +67,7 @@ abstract class Fixture implements FixtureInterface, \IteratorAggregate, \ArrayAc
      * @param mixed $offset
      * @return mixed|object|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?: null;

--- a/src/RestTestCase.php
+++ b/src/RestTestCase.php
@@ -20,22 +20,12 @@ abstract class RestTestCase extends TestCase
     use InteractWithContainer;
     use MakesHttpRequests;
 
-    /**
-     * @var Application
-     */
     protected Application $app;
-    /**
-     * @var ContainerInterface
-     */
+
     protected ContainerInterface $container;
-    /**
-     * @var array
-     */
+
     protected array $serverParams = [];
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         BypassFinals::enable();
@@ -46,14 +36,8 @@ abstract class RestTestCase extends TestCase
         $this->setUpTraits();
     }
 
-    /**
-     * @return Application
-     */
     abstract protected function createApplication(): Application;
 
-    /**
-     * @return void
-     */
     protected function setUpTraits(): void
     {
         $results = [];
@@ -81,9 +65,6 @@ abstract class RestTestCase extends TestCase
         return $traits;
     }
 
-    /**
-     * @return void
-     */
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/src/Traits/MakesHttpRequests.php
+++ b/src/Traits/MakesHttpRequests.php
@@ -141,7 +141,7 @@ trait MakesHttpRequests
         array $server = [],
         ?string $content = null
     ): TestResponse {
-        $server['REQUEST_METHOD'] = \strtolower($method);
+        $server['REQUEST_METHOD'] = \strtoupper($method);
         $server['HTTP_HOST'] = 'localhost';
         $server['REQUEST_URI'] = $uri;
 

--- a/tests/RestTestCaseTest.php
+++ b/tests/RestTestCaseTest.php
@@ -151,7 +151,7 @@ class RestTestCaseTest extends TestCase
         $headers = [
             'X-Test-Header' => 'test',
         ];
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) use ($query, $headers) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) use ($query, $headers) {
             self::assertSame($query, $request->getQueryParams());
             self::assertTrue(\in_array($headers['X-Test-Header'], $request->getHeader('X-Test-Header')));
             return new JsonResponse(['response' => 'test']);
@@ -181,7 +181,7 @@ class RestTestCaseTest extends TestCase
 
         $header = 'Test';
 
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse(['response' => 'test'], 200, $request->getHeaders());
         });
 
@@ -195,7 +195,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse(['response' => 'test'], 200, $request->getHeaders());
         });
 
@@ -209,7 +209,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse(['response' => 'test'], 200, $request->getHeaders());
         });
 
@@ -223,7 +223,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse(['response' => 'test'], 200, $request->getHeaders());
         });
 
@@ -236,7 +236,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('post', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('POST', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -254,7 +254,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('post', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('POST', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -273,7 +273,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('put', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('PUT', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -291,7 +291,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('put', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('PUT', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -310,7 +310,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('patch', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('PATCH', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -328,7 +328,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('patch', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('PATCH', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -347,7 +347,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('delete', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('DELETE', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -365,7 +365,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('delete', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('DELETE', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getParsedBody());
         });
 
@@ -384,7 +384,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('options', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('OPTIONS', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getQueryParams());
         });
 
@@ -402,7 +402,7 @@ class RestTestCaseTest extends TestCase
         /** @var RouterInterface $router */
         $router = $this->app->getContainer()->get(RouterInterface::class);
 
-        $router->map('options', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('OPTIONS', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse($request->getQueryParams());
         });
 
@@ -429,7 +429,7 @@ class RestTestCaseTest extends TestCase
         $strategy = (new JsonStrategy(new ResponseFactory()))->setContainer($this->app->getContainer());
         $router->setStrategy($strategy);
 
-        $router->map('get', '/api/test', function (ServerRequestInterface $request) {
+        $router->map('GET', '/api/test', function (ServerRequestInterface $request) {
             return new JsonResponse([]);
         });
 


### PR DESCRIPTION
По поводу strtoupper() : в боилерплейте(и у меня в проекте) роуты мапятся с названием метода прописными буквами, из-за этого падали тесты, я погуглил и увидел, что правильно писать всегда прописными, всё-таки. Так же нужно будет добавить strtoupper() в сам фреймворк в метод map чтоб больше не тратить много времени на дебаг этой несостыковки.